### PR TITLE
Add --no-build flag

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -13,7 +13,10 @@ export function builder (yargs){
   .describe('concurrency', 'Number of functions to build and upload at one time')
   .default('concurrency', Infinity)
   .alias('concurrency', 'c')
+  .describe('build', 'Build functions before deployment. Use --no-build to skip this step')
+  .default('build', true)
   .example('shep deploy production', 'Deploy all functions with production env variables')
+  .example('shep deploy production --no-build', 'Deploy all functions as currently built in the dist folder')
   .example('shep deploy production create-user', 'Deploy only the create-user function')
   .example('shep deploy production *-user', 'Deploy only functions matching the pattern *-user')
 }

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -13,6 +13,7 @@ export default function(opts){
   const concurrency = opts.concurrency || Infinity
   const env = opts.env
   const region = opts.region
+  const performBuild = opts.build
 
   AWS.config.update({region: region})
 
@@ -23,8 +24,9 @@ export default function(opts){
 
 
   function buildAndUploadFunction(name) {
-    return build(name, env)
-    .then(() => upload(name))
+    return Promise.resolve()
+    .then(() => { if (performBuild === true) return build(name, env) })
+    .then(() => upload(name) )
   }
 
   function pushAndDeployApi(funcs){


### PR DESCRIPTION
Allows deploy/build to be executed separately. Very helpful for shell scripting with shep.