### PR TITLE
Update testdouble version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.7.2",
-    "testdouble": "^1.4.1"
+    "testdouble": "^1.6.1"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
The `promiseConstructor` config option was introduced in testdouble 1.6.1