### PR TITLE
Add ability to configure AWS during shep new

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "execa": "^0.4.0",
     "fs-extra-promise": "^0.4.1",
     "inquirer": "^1.0.3",
-    "listr": "^0.6.1",
+    "listr": "^0.7.0",
     "lodash.kebabcase": "^4.1.1",
     "lodash.merge": "^4.6.0",
     "loud-rejection": "^1.6.0",

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -8,6 +8,20 @@ const questions = [
     name: 'path',
     message: 'Project folder name',
     default: 'my-api'
+  },
+  {
+    type: 'input',
+    name: 'region',
+    message: 'Region for project',
+    default: 'us-east-1',
+    config: true
+  },
+  {
+    type: 'input',
+    name: 'rolename',
+    message: 'Enter the name of the IAM role which you wish to use, if it is not found it will be created',
+    default: 'shepRole',
+    config: true
   }
 ]
 
@@ -16,12 +30,16 @@ export const desc = 'Create a new shep project'
 export function builder (yargs) {
   return yargs
   .describe('path', 'Location to create the new shep project')
+  .boolean('skip-config')
+  .describe('skip-config', 'Skips configuring shep project')
+  .describe('region', 'Region for new shep project')
+  .describe('rolename', 'Name of IAM Role which will be used to execute Lambda functions')
   .example('shep new', 'Launch an interactive CLI')
   .example('shep new my-api', 'Generates a project at `my-api`')
 }
 
 export function handler (opts) {
-  inquirer.prompt(questions.filter((q) => !opts[q.name]))
+  inquirer.prompt(questions.filter((q) => !opts[q.name] && (!opts.skipConfig || !q.config)))
   .then((inputs) => merge({}, inputs, opts))
   .then(_new)
 }

--- a/src/new/index.js
+++ b/src/new/index.js
@@ -1,4 +1,5 @@
 import { mkdir, writeFile } from '../util/modules/fs'
+import { getRole, createRole } from '../util/aws/iam'
 import * as templates from './templates'
 import Promise from 'bluebird'
 import exec from '../util/modules/exec'
@@ -6,58 +7,83 @@ import listr from '../util/modules/listr'
 
 export default function run (opts) {
   const path = opts.path
+  const rolename = opts.rolename
+  const region = opts.region
 
   const tasks = listr([
+    {
+      title: `Setup IAM Role`,
+      task: setupIam
+    },
     {
       title: `Create ${path}/`,
       task: () => mkdir(path)
     },
     {
       title: 'Create Subdirectories',
-      task: () => createSubDirs(path)
+      task: createSubDirs
     },
     {
       title: 'Create Files',
-      task: () => createFiles(path)
+      task: createFiles
     },
     {
       title: 'Install Depedencies',
-      task: () => npmInstall(path)
+      task: npmInstall
     },
     {
       title: 'Initialize Git',
-      task: () => initGit(path)
+      task: initGit
     }
   ], opts.quiet)
 
-  return tasks.run()
+  return tasks.run({ path, rolename, region })
 }
 
-function createSubDirs (path) {
+function setupIam (context) {
+  const rolename = context.rolename
+
+  if (!rolename) {
+    return Promise.resolve()
+  }
+
+  return getRole(rolename)
+  .catch(err => {
+    if (err.statusCode === 404) return createRole(rolename)
+    return Promise.reject(err)
+  })
+  .tap(arn => {
+    context.arn = arn
+  })
+}
+
+function createSubDirs ({ path }) {
   return Promise.all([
     mkdir(path + '/functions'),
     mkdir(path + '/config')
   ])
 }
 
-function createFiles (path) {
+function createFiles ({ path, arn, region }) {
+  const accountId = (/[0-9]{12}(?=:)/.exec(arn) || [ '' ])[0]
+
   return Promise.all([
-    writeFile(path + '/package.json', templates.pkg(path)),
+    writeFile(path + '/package.json', templates.pkg({ apiName: path, region, accountId })),
     writeFile(path + '/config/development.js', templates.env('development')),
     writeFile(path + '/config/beta.js', templates.env('beta')),
     writeFile(path + '/config/production.js', templates.env('production')),
     writeFile(path + '/.gitignore', templates.gitignore()),
     writeFile(path + '/README.md', templates.readme(path)),
-    writeFile(path + '/lambda.json', templates.lambda()),
+    writeFile(path + '/lambda.json', templates.lambda(arn)),
     writeFile(path + '/api.json', templates.api(path)),
     writeFile(path + '/webpack.config.js', templates.webpack())
   ])
 }
 
-function npmInstall (path) {
+function npmInstall ({ path }) {
   return exec('npm', ['install'], { cwd: path })
 }
 
-function initGit (path) {
+function initGit ({ path }) {
   return exec('git', ['init'], { cwd: path })
 }

--- a/src/new/index.js
+++ b/src/new/index.js
@@ -48,10 +48,7 @@ function setupIam (context) {
   }
 
   return getRole(rolename)
-  .catch(err => {
-    if (err.statusCode === 404) return createRole(rolename)
-    return Promise.reject(err)
-  })
+  .catch({ code: 'NoSuchEntity' }, () => createRole(rolename))
   .tap(arn => {
     context.arn = arn
   })

--- a/src/new/templates.js
+++ b/src/new/templates.js
@@ -22,11 +22,11 @@ node_modules/*
 config/*`
 }
 
-export function lambda () {
+export function lambda (arn = '') {
   let obj = {
     Handler: 'index.handler',
     MemorySize: 128,
-    Role: '',
+    Role: arn,
     Timeout: 10,
     Runtime: 'nodejs4.3'
   }
@@ -34,7 +34,22 @@ export function lambda () {
   return JSON.stringify(obj, null, 2)
 }
 
-export function pkg (apiName) {
+export function lambdaRole () {
+  return `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}`
+}
+
+export function pkg ({ apiName, accountId = '', region = '' }) {
   let obj = {
     name: apiName,
     version: '1.0.0',
@@ -46,8 +61,8 @@ export function pkg (apiName) {
       minimatch: '3.0.3'
     },
     shep: {
-      region: '',
-      accountId: '',
+      region: region,
+      accountId: accountId,
       apiId: ''
     }
   }

--- a/src/util/aws/iam.js
+++ b/src/util/aws/iam.js
@@ -1,0 +1,19 @@
+import AWS from './'
+import { lambdaRole } from '../../new/templates'
+
+export function createRole (name) {
+  const iam = new AWS.IAM()
+  const params = {
+    RoleName: name,
+    AssumeRolePolicyDocument: lambdaRole()
+  }
+
+  return iam.createRole(params).promise().get('Role').get('Arn')
+}
+
+export function getRole (name) {
+  const iam = new AWS.IAM()
+  const params = { RoleName: name }
+
+  return iam.getRole(params).promise().get('Role').get('Arn')
+}

--- a/src/util/aws/iam.js
+++ b/src/util/aws/iam.js
@@ -17,3 +17,13 @@ export function getRole (name) {
 
   return iam.getRole(params).promise().get('Role').get('Arn')
 }
+
+export function attachPolicy (name) {
+  const iam = new AWS.IAM()
+  const params = {
+    PolicyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+    RoleName: name
+  }
+
+  return iam.attachRolePolicy(params).promise()
+}

--- a/test/new/index-new-role.js
+++ b/test/new/index-new-role.js
@@ -11,7 +11,7 @@ const accountId = '123412341234'
 const roleArn = `arn:aws:iam:${accountId}:role/${rolename}`
 const templates = td.replace('../../src/new/templates')
 const iam = td.replace('../../src/util/aws/iam')
-td.when(iam.getRole(rolename)).thenReturn(Promise.reject({ statusCode: 404 }))
+td.when(iam.getRole(rolename)).thenReturn(Promise.reject({ code: 'NoSuchEntity' }))
 td.when(iam.createRole(rolename)).thenReturn(Promise.resolve(roleArn))
 
 test.before(() => {

--- a/test/new/index-new-role.js
+++ b/test/new/index-new-role.js
@@ -1,0 +1,27 @@
+import test from 'ava'
+import Promise from 'bluebird'
+import { fs } from '../helpers/fs'
+import { exec } from '../helpers/exec'
+import td from '../helpers/testdouble'
+
+const rolename = 'fooRole'
+const region = 'us-east-1'
+const path = 'foo-path'
+const accountId = '123412341234'
+const roleArn = `arn:aws:iam:${accountId}:role/${rolename}`
+const templates = td.replace('../../src/new/templates')
+const iam = td.replace('../../src/util/aws/iam')
+td.when(iam.getRole(rolename)).thenReturn(Promise.reject({ statusCode: 404 }))
+td.when(iam.createRole(rolename)).thenReturn(Promise.resolve(roleArn))
+
+test.before(() => {
+  const shep = require('../../src/index')
+  return shep.new({ region, rolename, path, quiet: true })
+})
+
+test('Creates role and writes configured templates', () => {
+  td.verify(fs.writeFile(), { ignoreExtraArgs: true })
+  td.verify(exec(), { ignoreExtraArgs: true })
+  td.verify(templates.pkg({ apiName: path, region, accountId }))
+  td.verify(templates.lambda(roleArn))
+})

--- a/test/new/index-new-role.js
+++ b/test/new/index-new-role.js
@@ -24,4 +24,5 @@ test('Creates role and writes configured templates', () => {
   td.verify(exec(), { ignoreExtraArgs: true })
   td.verify(templates.pkg({ apiName: path, region, accountId }))
   td.verify(templates.lambda(roleArn))
+  td.verify(iam.attachPolicy(rolename))
 })

--- a/test/new/index-prexisting-role.js
+++ b/test/new/index-prexisting-role.js
@@ -1,0 +1,31 @@
+import test from 'ava'
+import Promise from 'bluebird'
+import { fs } from '../helpers/fs'
+import { exec } from '../helpers/exec'
+import td from '../helpers/testdouble'
+
+const rolename = 'fooRole'
+const region = 'us-east-1'
+const path = 'foo-path'
+const accountId = '123412341234'
+const roleArn = `arn:aws:iam:${accountId}:role/${rolename}`
+const templates = td.replace('../../src/new/templates')
+const iam = td.replace('../../src/util/aws/iam')
+td.when(iam.getRole(rolename)).thenReturn(Promise.resolve(roleArn))
+
+test.before(() => {
+  const shep = require('../../src/index')
+  return shep.new({ region, rolename, path, quiet: true })
+})
+
+test('If role is found, no role is created', () => {
+  td.verify(iam.createRole(), { times: 0, ignoreExtraArgs: true })
+  td.verify(fs.writeFile(), { ignoreExtraArgs: true })
+  td.verify(exec(), { ignoreExtraArgs: true })
+})
+
+test('Wrote configured templates', () => {
+  td.verify(templates.pkg({ apiName: path, region, accountId }))
+  td.verify(templates.lambda(roleArn))
+})
+

--- a/test/new/index-prexisting-role.js
+++ b/test/new/index-prexisting-role.js
@@ -20,6 +20,7 @@ test.before(() => {
 
 test('If role is found, no role is created', () => {
   td.verify(iam.createRole(), { times: 0, ignoreExtraArgs: true })
+  td.verify(iam.attachPolicy(), { times: 0, ignoreExtraArgs: true })
   td.verify(fs.writeFile(), { ignoreExtraArgs: true })
   td.verify(exec(), { ignoreExtraArgs: true })
 })

--- a/test/new/index.js
+++ b/test/new/index.js
@@ -1,12 +1,19 @@
 import test from 'ava'
+import td from '../helpers/testdouble'
 import { createdDir, wroteFile } from '../helpers/fs'
 import { didExec } from '../helpers/exec'
 
 const path = 'foo-api'
+const iam = td.replace('../../src/util/aws/iam')
 
 test.before(() => {
   const shep = require('../../src/index')
   return shep.new({ path, quiet: true })
+})
+
+test('No calls to AWS if no rolename', () => {
+  td.verify(iam.getRole(), { times: 0, ignoreExtraArgs: true })
+  td.verify(iam.createRole(), { times: 0, ignoreExtraArgs: true })
 })
 
 test(createdDir, `${path}/functions`)
@@ -22,3 +29,4 @@ test(wroteFile, `${path}/webpack.config.js`)
 
 test(didExec, 'npm', 'install')
 test(didExec, 'git', 'init')
+


### PR DESCRIPTION
Important to note that this works on the assumption that users have AWS configured on their computer with a user which has the ability to create roles. Going from scratch to functional APIG/Lambda project is now just 
```
shep new
cd my_api
shep generate endpoint
shep deploy
```