### PR TITLE
Fix alias setting to no longer use $LATEST

### DIFF
--- a/src/util/aws/lambda.js
+++ b/src/util/aws/lambda.js
@@ -8,10 +8,16 @@ export function putFunction (config, ZipFile) {
 
   const FunctionName = config.FunctionName
   const Publish = true
+  let functionVersion
 
   return lambda.getFunction({ FunctionName }).promise()
   .then(() => lambda.updateFunctionCode({ ZipFile, FunctionName, Publish }).promise())
+  .tap(({ Version }) => { functionVersion = Version })
   .then(() => lambda.updateFunctionConfiguration(config).promise())
+  .then((func) => {
+    func['Version'] = functionVersion
+    return Promise.resolve(func)
+  })
   .catch({ code: 'ResourceNotFoundException' }, () => {
     const params = merge(config, { Publish, Code: { ZipFile } })
     return lambda.createFunction(params).promise()

--- a/src/util/aws/lambda.js
+++ b/src/util/aws/lambda.js
@@ -8,16 +8,10 @@ export function putFunction (config, ZipFile) {
 
   const FunctionName = config.FunctionName
   const Publish = true
-  let functionVersion
 
   return lambda.getFunction({ FunctionName }).promise()
-  .then(() => lambda.updateFunctionCode({ ZipFile, FunctionName, Publish }).promise())
-  .tap(({ Version }) => { functionVersion = Version })
   .then(() => lambda.updateFunctionConfiguration(config).promise())
-  .then((func) => {
-    func['Version'] = functionVersion
-    return Promise.resolve(func)
-  })
+  .then(() => lambda.updateFunctionCode({ ZipFile, FunctionName, Publish }).promise())
   .catch({ code: 'ResourceNotFoundException' }, () => {
     const params = merge(config, { Publish, Code: { ZipFile } })
     return lambda.createFunction(params).promise()


### PR DESCRIPTION
Apparently `AWS.Lambda.updateFunctionCode` will return a Function object with `Version` being set to the numerical version of the code while `AWS.Lambda.updateFunctionConfiguration` will return the Function object with `Version` being set to `$LATEST`. This ended up setting whatever alias was just deployed to `$LATEST` instead of numerical version.