### PR TITLE
@wip Warn on missing description field

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -21,7 +21,8 @@ example:
 
 ```json
 {
-  "FunctionName": "$PROJECT_NAME-$FUNCTION_NAME"
+  "FunctionName": "$PROJECT_NAME-$FUNCTION_NAME",
+  "Description": ""
 }
 ```
 

--- a/src/generate-function/templates.js
+++ b/src/generate-function/templates.js
@@ -3,9 +3,9 @@ export function index () {
 
 export function handler(event, context, callback) {
   // Replace below with your own code!
-  console.log(event)
-  console.log(context)
-  console.log(config)
+  console.log(JSON.stringify(event))
+  console.log(JSON.stringify(context))
+  console.log(JSON.stringify(config))
 
   callback(null, { statusCode: 200, headers: {}, body: 'success!' })
 }`
@@ -28,7 +28,8 @@ export function event () {
 
 export function lambda (name) {
   let obj = {
-    FunctionName: name
+    FunctionName: name,
+    Description: ''
   }
 
   return JSON.stringify(obj, null, 2)

--- a/src/util/load.js
+++ b/src/util/load.js
@@ -32,6 +32,10 @@ export function lambdaConfig (name) {
   const functionConfig = readJSONSync(`functions/${name}/lambda.json`)
   const projectConfig = readJSONSync(`lambda.json`)
 
+  if (!functionConfig.Description) {
+    console.log(`Warning: "functions/${name}/lambda.json" is missing a "Description" field.`)
+  }
+
   return Object.assign(projectConfig, functionConfig)
 }
 


### PR DESCRIPTION
Add in a warning if there's no description field on the lambda function. Because of the prompt however the warning isn't seen. Any suggestions on how to work around this?

Would close #103 