### PR TITLE
Use the locally installed shep if available

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,21 @@
 #! /usr/bin/env node
-require('./lib/cli')
+var resolve = require('resolve').sync
+
+var shepGlobalPath = './lib/cli'
+var shepGlobalVersion = require('./package.json').version
+try {
+  var shepLocalPath = resolve('shep/lib/cli', {basedir: process.cwd()})
+  var shepLocalVersion = require(resolve('shep/package.json', {basedir: process.cwd()})).version
+} catch (e) { }
+
+if (process.argv.indexOf('--version') !== -1) {
+  console.log('shep/cli', shepGlobalVersion)
+  console.log('shep', shepLocalVersion || shepGlobalVersion)
+  process.exit()
+}
+
+var cliPath = shepLocalPath || shepGlobalPath
+var cli = require(cliPath)
+if (typeof cli === 'function') {
+  cli()
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "standard",
     "prepublish": "npm run compile"
   },
+  "engines" : {
+    "node" : ">=4.0.0"
+  },
   "keywords": [
     "serverless",
     "serverless framework",
@@ -45,6 +48,7 @@
     "lodash.merge": "^4.6.0",
     "loud-rejection": "^1.6.0",
     "minimatch": "^3.0.3",
+    "resolve": "^1.1.7",
     "stream-buffers": "^3.0.0",
     "yargs": "^6.0.0"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,13 +1,16 @@
 import loudRejection from 'loud-rejection'
+import yargs from 'yargs'
 
-loudRejection()
+export default function cli () {
+  loudRejection()
 
-require('yargs')
-  .wrap(120)
-  .usage('Usage: $0 <command> [options]')
-  .demand(1)
-  .commandDir('./commands')
-  .version()
-  .help()
-  .strict()
-  .argv
+  yargs
+    .wrap(120)
+    .usage('Usage: $0 <command> [options]')
+    .demand(1)
+    .commandDir('./commands')
+    .version()
+    .help()
+    .strict()
+    .argv
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,5 @@ export { default as build } from './build'
 export { default as generateFunction } from './generate-function'
 export { default as generateEndpoint } from './generate-endpoint'
 export { default as generateWebpack } from './generate-webpack'
+export { version } from '../package.json'
+


### PR DESCRIPTION
This change uses the resolve plugin to find the locally installed shep package if there is one. If there isn't it loads the cli as usual from it's own package. I'm not wild about the warnings but I'm not sure how we want to display this information if we want to display this information. 

Grunt will warn you if there is no locally installed version.

Bugs:
- `shep --version` will always give you the version of the global module due to something about `yargs`
- no tests

![screen shot 2016-11-17 at 12 22 22 pm](https://cloud.githubusercontent.com/assets/25966/20399902/b8960ede-acc0-11e6-9d7d-3a724d150690.png)

Closes #111