### PR TITLE
Add better error message on invalid handler function

### DIFF
--- a/src/run/index.js
+++ b/src/run/index.js
@@ -59,6 +59,10 @@ function runFunction (opts) {
 
     const func = requireProject(`dist/${name}/${fileName}`)[handler]
 
+    if (typeof func !== 'function') {
+      return Promise.reject(new Error(`Handler function provided is not a function. Please verify that there exists a handler function exported as ${handler} in dist/${name}/${fileName}.js`))
+    }
+
     return await Promise.map(events, (eventFilename) => {
       const event = requireProject(`functions/${name}/events/${eventFilename}`)
       return new Promise((resolve) => {


### PR DESCRIPTION
Currently this will fail out the entire run command. I think that this is a impactful enough issue that it warrants that behavior. 