### PR TITLE
use execa.shell so npm and build commands get an env

### DIFF
--- a/src/new/index.js
+++ b/src/new/index.js
@@ -82,6 +82,6 @@ function createFiles ({ path, arn, region }) {
 }
 
 function npmInstall ({ path }) {
-  return exec('npm', ['install'], { cwd: path })
+  return exec('npm install', { cwd: path })
 }
 

--- a/src/util/build-functions.js
+++ b/src/util/build-functions.js
@@ -2,16 +2,11 @@ import exec from './modules/exec'
 import { pkg } from './load'
 
 export default function (PATTERN, NODE_ENV) {
-  const buildCommand = pkg().shep && pkg().shep.buildCommand ? pkg().shep.buildCommand : 'webpack --bail'
-  const [command, args] = parseBuildCommand(buildCommand)
-  return exec(command, args, { env: { PATTERN, NODE_ENV } })
+  const { shep } = pkg()
+  const buildCommand = shep && shep.buildCommand || 'webpack --bail'
+  return exec(buildCommand, { env: { ...process.env, PATTERN, NODE_ENV } })
   .catch({ code: 'ENOENT' }, (e) => {
     console.warn('No locally installed webpack found. Verify that webpack is installed')
     throw e
   })
-}
-
-function parseBuildCommand (command) {
-  const [com, ...args] = command.split(' ')
-  return [com, args]
 }

--- a/src/util/modules/exec.js
+++ b/src/util/modules/exec.js
@@ -1,3 +1,3 @@
 import execa from 'execa'
 import Promise from 'bluebird'
-export default Promise.method(execa)
+export default Promise.method(execa.shell)

--- a/test/build/index-custom.js
+++ b/test/build/index-custom.js
@@ -2,9 +2,7 @@ import test from 'ava'
 import { exec, didExec } from '../helpers/exec'
 import td from '../helpers/testdouble'
 
-const command = 'custom-build'
-const args = ['--cool-flag', '-x', '6']
-const buildCommand = `${command} ${args.join(' ')}`
+const buildCommand = 'custom-build --cool-flag -x 6'
 
 const load = td.replace('../../src/util/load')
 td.when(load.pkg()).thenReturn({ shep: { buildCommand } })
@@ -16,4 +14,4 @@ test.before(() => {
   return shep.build({ quiet: true })
 })
 
-test(didExec, command, args)
+test(didExec, buildCommand)

--- a/test/build/index-no-webpack.js
+++ b/test/build/index-no-webpack.js
@@ -5,7 +5,7 @@ import td from '../helpers/testdouble'
 let error = new Error()
 error.code = 'ENOENT'
 
-td.when(exec('webpack', ['--bail']), { ignoreExtraArgs: true }).thenReject(error)
+td.when(exec('webpack --bail'), { ignoreExtraArgs: true }).thenReject(error)
 td.replace(console, 'warn')
 
 test('Logs to console when no webpack found', async (t) => {

--- a/test/build/index.js
+++ b/test/build/index.js
@@ -2,11 +2,11 @@ import test from 'ava'
 import { exec, didExec } from '../helpers/exec'
 import td from '../helpers/testdouble'
 
-td.when(exec('webpack', ['--bail']), { ignoreExtraArgs: true }).thenReturn(Promise.resolve())
+td.when(exec('webpack --bail'), { ignoreExtraArgs: true }).thenReturn(Promise.resolve())
 
 test.before(() => {
   const shep = require('../../src')
   return shep.build({ quiet: true })
 })
 
-test(didExec, 'webpack', ['--bail'])
+test(didExec, 'webpack --bail')

--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -2,8 +2,8 @@ import td from 'testdouble'
 
 const exec = td.replace('../../src/util/modules/exec')
 
-function didExec (t, cmd, args, options = {}) {
-  td.verify(exec(cmd, args, td.matchers.contains(options)))
+function didExec (t, cmd, options = {}) {
+  td.verify(exec(cmd, td.matchers.contains(options)))
 }
 
 didExec.title = (providedTitle, cmd, subcmd) => `Executed ${cmd} ${subcmd || ''}`

--- a/test/new/index.js
+++ b/test/new/index.js
@@ -27,5 +27,5 @@ test(wroteFile, `${path}/.gitignore`)
 test(wroteFile, `${path}/README.md`)
 test(wroteFile, `${path}/webpack.config.js`)
 
-test(didExec, 'npm', ['install'])
+test(didExec, 'npm install')
 


### PR DESCRIPTION
This provides the local env to webpack which is needed for some webpack plugins. Like anything that wants to run commands, read env vars, etc. This also lets people use proxies with npm.

Smoke tested a build with `webpack-shell-plugin` and a `shep new`