### PR TITLE
Fix `shep config set` with variables containing `=`

### DIFF
--- a/src/commands/config/set.js
+++ b/src/commands/config/set.js
@@ -13,9 +13,9 @@ export function builder (yargs) {
 
 export async function handler (opts) {
   let envVars = {}
-  opts.vars.forEach((varPair) => {
-    const split = varPair.split('=')
-    envVars[split[0]] = split[1]
+  opts.vars.forEach(function (varPair) {
+    const [key, value] = varPair.match(/(.*?)=(.*)/).slice(1)
+    envVars[key] = value
   })
   opts.vars = envVars
 


### PR DESCRIPTION
While trying to set a `DATABASE_URL` via `shep config set`, I discovered that query params break `shep config set`. Currently, `shep config set` splits on `=` and therefore only gets whatever part of a variable value is before any contained `=`.

This patch resolves the issue by only splitting on the first `=` in each pair.